### PR TITLE
feat: enhance connection handling and re-authentication for qBittorrent instances

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qbittorrent-mcp-rs"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 
 [dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest AS chef
+FROM rust:bookworm AS chef
 # We only pay the installation cost once,
 # it will be cached from the second build onwards
 RUN cargo install cargo-chef

--- a/src/client.rs
+++ b/src/client.rs
@@ -50,6 +50,10 @@ impl QBitClient {
         &self.base_url
     }
 
+    pub fn has_credentials(&self) -> bool {
+        self.username.is_some()
+    }
+
     pub async fn login(&self) -> Result<()> {
         let base_url = self.base_url.trim_end_matches('/');
         let url = format!("{}/api/v2/auth/login", base_url);

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -1820,10 +1820,12 @@ impl McpServer {
         let mut last_rids: HashMap<String, i64> = HashMap::new();
         let mut notified_finished: HashMap<String, std::collections::HashSet<String>> =
             HashMap::new();
+        let mut was_connected: HashMap<String, bool> = HashMap::new();
 
         for name in self.clients.keys() {
             last_rids.insert(name.clone(), 0);
             notified_finished.insert(name.clone(), std::collections::HashSet::new());
+            was_connected.insert(name.clone(), false);
         }
 
         loop {
@@ -1839,6 +1841,10 @@ impl McpServer {
                 let rid = *last_rids.get(name).unwrap_or(&0);
                 match client.get_main_data(rid).await {
                     Ok(data) => {
+                        if !*was_connected.get(name).unwrap_or(&false) {
+                            info!("Connected to qBittorrent instance '{}'", name);
+                            was_connected.insert(name.clone(), true);
+                        }
                         last_rids.insert(name.clone(), data.rid);
 
                         // Track finished torrents to notify only once
@@ -1895,7 +1901,23 @@ impl McpServer {
                     }
                     Err(e) => {
                         if self.is_running() {
-                            error!("Polling error for instance {}: {}", name, e);
+                            if *was_connected.get(name).unwrap_or(&false) {
+                                error!(
+                                    "Lost connection to qBittorrent instance '{}': {}",
+                                    name, e
+                                );
+                                was_connected.insert(name.clone(), false);
+                                last_rids.insert(name.clone(), 0);
+                            }
+                            if client.has_credentials() {
+                                match client.login().await {
+                                    Ok(()) => info!(
+                                        "Re-authenticated to qBittorrent instance '{}'",
+                                        name
+                                    ),
+                                    Err(_) => {}
+                                }
+                            }
                         }
                     }
                 }

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -1902,20 +1902,13 @@ impl McpServer {
                     Err(e) => {
                         if self.is_running() {
                             if *was_connected.get(name).unwrap_or(&false) {
-                                error!(
-                                    "Lost connection to qBittorrent instance '{}': {}",
-                                    name, e
-                                );
+                                error!("Lost connection to qBittorrent instance '{}': {}", name, e);
                                 was_connected.insert(name.clone(), false);
                                 last_rids.insert(name.clone(), 0);
                             }
                             if client.has_credentials() {
-                                match client.login().await {
-                                    Ok(()) => info!(
-                                        "Re-authenticated to qBittorrent instance '{}'",
-                                        name
-                                    ),
-                                    Err(_) => {}
+                                if let Ok(()) = client.login().await {
+                                    info!("Re-authenticated to qBittorrent instance '{}'", name)
                                 }
                             }
                         }

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -1906,10 +1906,8 @@ impl McpServer {
                                 was_connected.insert(name.clone(), false);
                                 last_rids.insert(name.clone(), 0);
                             }
-                            if client.has_credentials() {
-                                if let Ok(()) = client.login().await {
-                                    info!("Re-authenticated to qBittorrent instance '{}'", name)
-                                }
+                            if client.has_credentials() && client.login().await.is_ok() {
+                                info!("Re-authenticated to qBittorrent instance '{}'", name)
                             }
                         }
                     }


### PR DESCRIPTION
When the qBittorrent server restarts, its session cookie store is wiped. The MCP server holds a stale session cookie (SID) that returns HTTP 403 on every subsequent request. The event loop catches these errors, logs them, and continues — but never re-authenticates, so it stays broken indefinitely even after qBittorrent is back online. The container doesn't crash, so it never auto-restarts. The fix is to re-login in the event loop when a poll fails and reset the RID counter so the next successful poll fetches a full fresh snapshot.

Also pin Dockerfile chef stage to bookworm to match the runtime